### PR TITLE
Fix external marketplace link type usage

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -1,42 +1,54 @@
-import Link from "next/link";
 import { site } from "@/config/site";
 
 export default function MarketplacePage() {
-  const facebookUrl = site.social.facebookMarketplace.includes("place info here")
+  const facebookUrl = site.social.facebookMarketplace.includes(
+    "place info here"
+  )
     ? "#"
     : site.social.facebookMarketplace;
-  const ebayUrl = site.social.ebay.includes("place info here") ? "#" : site.social.ebay;
+  const ebayUrl = site.social.ebay.includes("place info here")
+    ? "#"
+    : site.social.ebay;
 
   return (
     <div className="container mx-auto space-y-8 px-4 py-16">
-      <h1 className="text-4xl font-bold tracking-tight">Marketplace Listings</h1>
+      <h1 className="text-4xl font-bold tracking-tight">
+        Marketplace Listings
+      </h1>
       <p className="text-muted-foreground">
-        We maintain an active presence on eBay and Facebook Marketplace so you can verify our reviews and browse current battery listings.
+        We maintain an active presence on eBay and Facebook Marketplace so you
+        can verify our reviews and browse current battery listings.
       </p>
       <div className="grid gap-6 md:grid-cols-2">
         <div className="rounded-xl border bg-card p-6 shadow-sm">
           <h2 className="text-xl font-semibold">Facebook Marketplace</h2>
           <p className="mt-2 text-sm text-muted-foreground">
-            View local listings, arrange pickup or delivery, and chat with us directly via Messenger.
+            View local listings, arrange pickup or delivery, and chat with us
+            directly via Messenger.
           </p>
-          <Link
+          <a
             href={facebookUrl}
             className="mt-4 inline-flex items-center text-sm font-medium text-primary hover:underline"
+            target="_blank"
+            rel="noreferrer"
           >
             Visit Facebook Marketplace →
-          </Link>
+          </a>
         </div>
         <div className="rounded-xl border bg-card p-6 shadow-sm">
           <h2 className="text-xl font-semibold">eBay Store</h2>
           <p className="mt-2 text-sm text-muted-foreground">
-            Nationwide shipping with freight coordination available. Check ratings, sold history, and warranty details.
+            Nationwide shipping with freight coordination available. Check
+            ratings, sold history, and warranty details.
           </p>
-          <Link
+          <a
             href={ebayUrl}
             className="mt-4 inline-flex items-center text-sm font-medium text-primary hover:underline"
+            target="_blank"
+            rel="noreferrer"
           >
             Visit our eBay store →
-          </Link>
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace Next.js Link components with standard anchors for external marketplace URLs
- add new tab and noreferrer attributes for marketplace links to avoid typed route issues

## Testing
- CI=1 pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e349fae838832e8a0dcf8248f42e12